### PR TITLE
Expose a summary class shell's own methods (#1957 follow-up)

### DIFF
--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/Util.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/Util.java
@@ -36,6 +36,7 @@ import com.ibm.wala.ipa.cha.IClassHierarchy;
 import com.ibm.wala.ipa.summaries.BypassClassTargetSelector;
 import com.ibm.wala.ipa.summaries.BypassMethodTargetSelector;
 import com.ibm.wala.ipa.summaries.LambdaMethodTargetSelector;
+import com.ibm.wala.ipa.summaries.MethodSummary;
 import com.ibm.wala.ipa.summaries.SummaryClassShellLoader;
 import com.ibm.wala.ipa.summaries.XMLMethodSummaryReader;
 import com.ibm.wala.types.ClassLoaderReference;
@@ -43,6 +44,7 @@ import com.ibm.wala.types.Descriptor;
 import com.ibm.wala.types.MethodReference;
 import com.ibm.wala.types.TypeName;
 import com.ibm.wala.types.TypeReference;
+import com.ibm.wala.util.collections.HashMapFactory;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.debug.Assertions;
 import com.ibm.wala.util.graph.Graph;
@@ -52,8 +54,11 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -209,11 +214,21 @@ public class Util {
     if (!(loader instanceof SummaryClassShellLoader registrar)) {
       return;
     }
+    // Group method summaries by declaring class, so each shell can expose its own methods.
+    Map<TypeReference, List<MethodSummary>> methodsByClass = HashMapFactory.make();
+    for (MethodSummary method : summary.getSummaries().values()) {
+      methodsByClass
+          .computeIfAbsent(method.getMethod().getDeclaringClass(), k -> new ArrayList<>())
+          .add(method);
+    }
     for (Map.Entry<TypeReference, TypeReference> entry :
         summary.getClassSuperclasses().entrySet()) {
       TypeReference type = entry.getKey();
       if (type.getClassLoader().equals(loader.getReference())) {
-        registrar.defineSummaryClassShell(type.getName(), entry.getValue().getName());
+        registrar.defineSummaryClassShell(
+            type.getName(),
+            entry.getValue().getName(),
+            methodsByClass.getOrDefault(type, Collections.emptyList()));
       }
     }
   }

--- a/core/src/main/java/com/ibm/wala/ipa/summaries/BypassSyntheticClassLoader.java
+++ b/core/src/main/java/com/ibm/wala/ipa/summaries/BypassSyntheticClassLoader.java
@@ -26,6 +26,7 @@ import com.ibm.wala.util.config.StringFilter;
 import java.io.IOException;
 import java.io.Reader;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -106,13 +107,19 @@ public class BypassSyntheticClassLoader implements IClassLoader, SummaryClassShe
 
   @Override
   public IClass defineSummaryClassShell(TypeName name, TypeName superName) {
+    return defineSummaryClassShell(name, superName, Collections.emptyList());
+  }
+
+  @Override
+  public IClass defineSummaryClassShell(
+      TypeName name, TypeName superName, Collection<MethodSummary> methods) {
     IClass existing = lookupClass(name);
     if (existing != null) {
       return existing;
     }
     TypeReference type = TypeReference.findOrCreate(me, name);
     TypeReference superType = superName == null ? null : TypeReference.findOrCreate(me, superName);
-    IClass shell = new SummaryClassShell(type, cha, superType);
+    IClass shell = new SummaryClassShell(type, cha, superType, methods);
     registerClass(name, shell);
     return shell;
   }

--- a/core/src/main/java/com/ibm/wala/ipa/summaries/SummaryClassShell.java
+++ b/core/src/main/java/com/ibm/wala/ipa/summaries/SummaryClassShell.java
@@ -18,20 +18,31 @@ import com.ibm.wala.core.util.strings.Atom;
 import com.ibm.wala.ipa.cha.IClassHierarchy;
 import com.ibm.wala.types.Selector;
 import com.ibm.wala.types.TypeReference;
+import com.ibm.wala.util.collections.HashMapFactory;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 
 /**
  * A minimal standalone shell {@link IClass} for a type modeled only by a summary. Unlike {@link
  * BypassSyntheticClass}, which wraps an existing "real" type, a shell stands on its own and is
- * positioned in the hierarchy at an explicitly declared superclass. It carries no members; its
- * purpose is to occupy a place in the class hierarchy so that source subclasses resolve their base.
- * See <a href="https://github.com/wala/WALA/issues/1957">#1957</a>.
+ * positioned in the hierarchy at an explicitly declared superclass. Its purpose is to occupy a
+ * place in the class hierarchy so that source subclasses resolve their base. It carries no fields;
+ * it exposes only the methods given to it as {@link MethodSummary summaries} (typically the {@code
+ * <method>} children of the {@code <class>} it was materialized from), as {@link
+ * SummarizedMethod}s. See <a href="https://github.com/wala/WALA/issues/1957">#1957</a>.
  */
 public class SummaryClassShell extends SyntheticClass {
 
   /** The declared superclass, or {@code null} for the language root type. */
   private final TypeReference superReference;
+
+  /** The summaries for this shell's own declared methods, keyed by selector. */
+  private final Map<Selector, MethodSummary> methodSummaries = HashMapFactory.make();
+
+  /** Lazily materialized {@link SummarizedMethod}s, keyed by selector. */
+  private final Map<Selector, IMethod> resolvedMethods = HashMapFactory.make();
 
   /**
    * @param type the type this shell represents
@@ -39,8 +50,25 @@ public class SummaryClassShell extends SyntheticClass {
    * @param superReference the declared superclass, or {@code null} for the language root type
    */
   public SummaryClassShell(TypeReference type, IClassHierarchy cha, TypeReference superReference) {
+    this(type, cha, superReference, Collections.emptyList());
+  }
+
+  /**
+   * @param type the type this shell represents
+   * @param cha the governing class hierarchy
+   * @param superReference the declared superclass, or {@code null} for the language root type
+   * @param methods summaries for the shell's own declared methods
+   */
+  public SummaryClassShell(
+      TypeReference type,
+      IClassHierarchy cha,
+      TypeReference superReference,
+      Collection<MethodSummary> methods) {
     super(type, cha);
     this.superReference = superReference;
+    for (MethodSummary method : methods) {
+      methodSummaries.put(method.getMethod().getSelector(), method);
+    }
   }
 
   @Override
@@ -67,7 +95,17 @@ public class SummaryClassShell extends SyntheticClass {
 
   @Override
   public IMethod getMethod(Selector selector) {
-    return null;
+    IMethod cached = resolvedMethods.get(selector);
+    if (cached != null) {
+      return cached;
+    }
+    MethodSummary summary = methodSummaries.get(selector);
+    if (summary == null) {
+      return null;
+    }
+    IMethod method = new SummarizedMethod(summary.getMethod(), summary, this);
+    resolvedMethods.put(selector, method);
+    return method;
   }
 
   @Override
@@ -82,7 +120,11 @@ public class SummaryClassShell extends SyntheticClass {
 
   @Override
   public Collection<? extends IMethod> getDeclaredMethods() {
-    return Collections.emptySet();
+    Collection<IMethod> result = new ArrayList<>(methodSummaries.size());
+    for (Selector selector : methodSummaries.keySet()) {
+      result.add(getMethod(selector));
+    }
+    return result;
   }
 
   @Override
@@ -112,7 +154,9 @@ public class SummaryClassShell extends SyntheticClass {
 
   @Override
   public Collection<? extends IMethod> getAllMethods() {
-    return Collections.emptySet();
+    // The shell models only its own summarized members; inherited methods are resolved through the
+    // class hierarchy via getSuperclass().
+    return getDeclaredMethods();
   }
 
   @Override

--- a/core/src/main/java/com/ibm/wala/ipa/summaries/SummaryClassShellLoader.java
+++ b/core/src/main/java/com/ibm/wala/ipa/summaries/SummaryClassShellLoader.java
@@ -13,6 +13,7 @@ package com.ibm.wala.ipa.summaries;
 import com.ibm.wala.classLoader.IClass;
 import com.ibm.wala.classLoader.IClassLoader;
 import com.ibm.wala.types.TypeName;
+import java.util.Collection;
 
 /**
  * A capability, implemented by class loaders that can introduce "shell" classes for types modeled
@@ -42,4 +43,24 @@ public interface SummaryClassShellLoader {
    * @return the registered (or pre-existing) class
    */
   IClass defineSummaryClassShell(TypeName name, TypeName superName);
+
+  /**
+   * Register a shell {@link IClass} that also exposes the given method summaries as its own
+   * declared methods, so that a walk of the shell (e.g. when resolving an inherited method on a
+   * subclass) finds them. The method bodies are still bound late by the usual bypass mechanism;
+   * only the declarations need to exist on the shell.
+   *
+   * <p>The default implementation ignores {@code methods} and delegates to {@link
+   * #defineSummaryClassShell(TypeName, TypeName)}; implementations whose shells can carry methods
+   * (such as the {@link BypassSyntheticClassLoader}) override this.
+   *
+   * @param name the type to register a shell for
+   * @param superName the shell's superclass, or {@code null} for this loader's language root type
+   * @param methods summaries for the methods the shell should declare
+   * @return the registered (or pre-existing) class
+   */
+  default IClass defineSummaryClassShell(
+      TypeName name, TypeName superName, Collection<MethodSummary> methods) {
+    return defineSummaryClassShell(name, superName);
+  }
 }

--- a/core/src/test/java/com/ibm/wala/core/tests/cha/SummaryClassShellTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/cha/SummaryClassShellTest.java
@@ -15,6 +15,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.ibm.wala.classLoader.IClass;
 import com.ibm.wala.classLoader.IClassLoader;
+import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.core.tests.callGraph.CallGraphTestUtil;
 import com.ibm.wala.core.tests.util.TestConstants;
 import com.ibm.wala.core.tests.util.WalaTestCase;
@@ -51,6 +52,18 @@ public class SummaryClassShellTest extends WalaTestCase {
         <classloader name="Synthetic">
           <class name="Base" super="Ljava/lang/Object"/>
           <class name="NotAShell"/>
+        </classloader>
+      </summary-spec>
+      """;
+
+  /** A shell whose {@code <class>} declares a method, which the shell should expose. */
+  private static final String XML_WITH_METHOD =
+      """
+      <summary-spec>
+        <classloader name="Synthetic">
+          <class name="WithMethod" super="Ljava/lang/Object">
+            <method name="foo" descriptor="()V"/>
+          </class>
         </classloader>
       </summary-spec>
       """;
@@ -138,6 +151,28 @@ public class SummaryClassShellTest extends WalaTestCase {
     assertThat(base.isReferenceType()).isTrue();
     assertThat(base.getModifiers()).isZero();
     assertThat(base.toString()).contains("Base");
+  }
+
+  /** A shell exposes the methods declared by its {@code <class>} as its own declared methods. */
+  @Test
+  public void testShellExposesItsSummaryMethods() throws ClassHierarchyException, IOException {
+    AnalysisScope scope = scope();
+    ClassHierarchy cha = ClassHierarchyFactory.make(scope);
+    Util.addSummaryClassShells(
+        cha.getLoader(scope.getSyntheticLoader()), read(scope, XML_WITH_METHOD));
+
+    IClass shell =
+        cha.lookupClass(TypeReference.findOrCreate(scope.getSyntheticLoader(), "LWithMethod"));
+    assertThat(shell).isInstanceOf(SummaryClassShell.class);
+
+    Selector foo = Selector.make("foo()V");
+    IMethod method = shell.getMethod(foo);
+    assertThat(method).isNotNull();
+    assertThat(method.getSelector()).isEqualTo(foo);
+    assertThat(method.getDeclaringClass()).isSameAs(shell);
+    assertThat(shell.getDeclaredMethods()).singleElement().isSameAs(method);
+    // The materialized method is cached.
+    assertThat(shell.getMethod(foo)).isSameAs(method);
   }
 
   /** Registering a shell twice returns the same class, and a null super defaults to the root. */


### PR DESCRIPTION
Stacked on top of [#1958](https://github.com/wala/WALA/pull/1958) (`1957-summary-class-shells`). Review that one first; this PR's diff is just the single follow-up commit. Toward wala/WALA#1957.

## What

#1958 registers a class shell before the CHA is built so a source subclass resolves its summary-modeled base. This follow-up lets that shell also carry the base's own methods, so a walk of the shell (for example, resolving an inherited method on the subclass) finds them. The method bodies are still bound late by the usual bypass mechanism; only the declarations need to exist on the shell.

## Change

- [`SummaryClassShell`](https://github.com/ponder-lab/WALA/blob/3cd29c2918b965892a9148a73bde7ab03e1c7b5e/core/src/main/java/com/ibm/wala/ipa/summaries/SummaryClassShell.java#L97) exposes the method summaries declared by its `<class>` (its `<method>` children) as its own declared methods, materialized lazily as `SummarizedMethod`s.
- [`SummaryClassShellLoader`](https://github.com/ponder-lab/WALA/blob/3cd29c2918b965892a9148a73bde7ab03e1c7b5e/core/src/main/java/com/ibm/wala/ipa/summaries/SummaryClassShellLoader.java#L63) gains a `defineSummaryClassShell(name, super, methods)` overload. It is a `default` that ignores `methods` and delegates to the no-methods version; the `BypassSyntheticClassLoader` overrides it. The no-methods 2-arg overload remains for a pure base shell.
- [`Util.addSummaryClassShells`](https://github.com/ponder-lab/WALA/blob/3cd29c2918b965892a9148a73bde7ab03e1c7b5e/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/Util.java#L218) groups the summary's methods by declaring class and hands each shell its own.

A loader whose shells cannot carry methods (the CAst module loaders' default) keeps the prior behavior; such a loader may override the hook to build a shell type that does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJxS9UvezNo842kqxmc1vS